### PR TITLE
add support for JavaScript variant languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "chalk": "~0.4.0",
     "colors-tmpl": "~0.1.0",
     "i18n-core": "^1.3.2",
+    "interpret": "^0.5.2",
     "map-async": "~0.1.1",
     "mkdirp": "~0.3.5",
     "msee": "~0.1.1",

--- a/workshopper.js
+++ b/workshopper.js
@@ -6,6 +6,7 @@ const argv         = require('optimist').argv
     , chalk        = require('chalk')
     , inherits     = require('util').inherits
     , EventEmitter = require('events').EventEmitter
+    , interpret    = require('interpret')
 
 const showMenu         = require('./exerciseMenu')
     , showLanguageMenu = require('./languageMenu')
@@ -461,12 +462,16 @@ Workshopper.prototype.getExerciseMeta = function (name) {
 
   dir = this.dirFromName(name)
 
+  var exerciseFileName = fs.readdirSync(dir).filter(function (filename) {
+    return !!interpret.jsVariants[path.extname(filename)]
+  })[0]
+
   return {
       name         : name
     , number       : number
     , dir          : dir
     , id           : util.idFromName(name)
-    , exerciseFile : path.join(dir, './exercise.js')
+    , exerciseFile : path.join(dir, exerciseFileName)
   }
 }
 


### PR DESCRIPTION
This adds support for writing exercises in JavaScript variant languages (CoffeeScript, TypeScript etc.) using the [interpret](https://github.com/tkellen/js-interpret) module.

For a basic illustration of the concept, see [qahava](https://github.com/suyash/qahava).

This comes with a PR for workshopper-exercise.

adventure can support other languages directly, see [qahava#adventure](https://github.com/suyash/qahava/tree/adventure), but I don't think something like that can work with the current setup of workshopper, hence this.

also note that while interpret has support for legacy modules, that has been avoided here because it is assumed that a workshopper is being written in the latest iteration of the language (in my opinion), but if that is also wanted, we can use [rechoir](https://github.com/tkellen/js-rechoir) directly.