### PR TITLE
(#138) fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In mid-term workshopper will be replaced with [`workshopper-adventure`](https://
 
 *Documentation is being written for the v1 rewrite right now! Ping @rvagg if you need anything. **learnyounode** is now using this new version, for now you can use it to see how this works.
 
-For now, [@linclark](https://github.com/linclark) has written a good introduction on creating your own workshop, available [here](http://lin-clark.com/blog/2014/07/01/authoring-nodejs-workshopper-lessons/).
+For now, [@linclark](https://github.com/linclark) has written a good introduction on creating your own workshop, available [here](https://github.com/linclark/lin-clark.com/blob/master/content/blog/2014/07/01/authoring-nodejs-workshopper-lessons.md).
 
 ## High-level overview
 


### PR DESCRIPTION
Resolves issue #138 

Lin Clark wrote some cool docs about how to make a workshopper, 
link in the README.md is currently broken, this pull request replaces with a link to the markdown file that made the blog post which was originally pointing to.